### PR TITLE
feat: add user registration endpoint

### DIFF
--- a/TaskFlow.API/Controllers/AuthController.cs
+++ b/TaskFlow.API/Controllers/AuthController.cs
@@ -21,4 +21,11 @@ public class AuthController : ControllerBase
         var token = await _mediator.Send(command);
         return Ok(new { token });
     }
+
+    [HttpPost("register")]
+    public async Task<IActionResult> Register([FromBody] RegisterUserCommand command)
+    {
+        var token = await _mediator.Send(command);
+        return CreatedAtAction(nameof(Login), new { token });
+    }
 }

--- a/TaskFlow.API/Middleware/ExceptionHandlingMiddleware.cs
+++ b/TaskFlow.API/Middleware/ExceptionHandlingMiddleware.cs
@@ -38,6 +38,11 @@ public class ExceptionHandlingMiddleware
             _logger.LogWarning(ex, "Unauthorized access attempt.");
             await WriteErrorResponse(context, HttpStatusCode.Unauthorized, ex.Message);
         }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex, "Conflict: {Message}", ex.Message);
+            await WriteErrorResponse(context, HttpStatusCode.Conflict, ex.Message);
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "An unhandled exception occurred.");

--- a/TaskFlow.Application/Features/Auth/RegisterUserCommand.cs
+++ b/TaskFlow.Application/Features/Auth/RegisterUserCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace TaskFlow.Application.Features.Auth;
+
+public record RegisterUserCommand(string Username, string Password) : IRequest<string>;

--- a/TaskFlow.Application/Features/Auth/RegisterUserHandler.cs
+++ b/TaskFlow.Application/Features/Auth/RegisterUserHandler.cs
@@ -1,0 +1,42 @@
+using MediatR;
+using TaskFlow.Application.Interfaces;
+using TaskFlow.Domain.Entities;
+using TaskFlow.Domain.Interfaces;
+
+namespace TaskFlow.Application.Features.Auth;
+
+public class RegisterUserHandler : IRequestHandler<RegisterUserCommand, string>
+{
+    private readonly IUserRepository _userRepository;
+    private readonly IPasswordHasher _passwordHasher;
+    private readonly IJwtTokenService _jwtTokenService;
+
+    public RegisterUserHandler(
+        IUserRepository userRepository,
+        IPasswordHasher passwordHasher,
+        IJwtTokenService jwtTokenService)
+    {
+        _userRepository = userRepository;
+        _passwordHasher = passwordHasher;
+        _jwtTokenService = jwtTokenService;
+    }
+
+    public async Task<string> Handle(RegisterUserCommand request, CancellationToken cancellationToken)
+    {
+        var existing = await _userRepository.GetByUsernameAsync(request.Username);
+        if (existing is not null)
+            throw new InvalidOperationException($"Username '{request.Username}' is already taken.");
+
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Username = request.Username,
+            PasswordHash = _passwordHasher.Hash(request.Password),
+            Role = "User",
+        };
+
+        await _userRepository.AddAsync(user);
+
+        return _jwtTokenService.GenerateToken(user.Id, user.Username, user.Role);
+    }
+}

--- a/TaskFlow.Application/Features/Auth/Validators/RegisterUserCommandValidator.cs
+++ b/TaskFlow.Application/Features/Auth/Validators/RegisterUserCommandValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+
+namespace TaskFlow.Application.Features.Auth.Validators;
+
+public class RegisterUserCommandValidator : AbstractValidator<RegisterUserCommand>
+{
+    public RegisterUserCommandValidator()
+    {
+        RuleFor(x => x.Username)
+            .NotEmpty().WithMessage("Username is required.")
+            .MinimumLength(3).WithMessage("Username must be at least 3 characters.")
+            .MaximumLength(50).WithMessage("Username must not exceed 50 characters.")
+            .Matches("^[a-zA-Z0-9_]+$").WithMessage("Username may only contain letters, numbers and underscores.");
+
+        RuleFor(x => x.Password)
+            .NotEmpty().WithMessage("Password is required.")
+            .MinimumLength(8).WithMessage("Password must be at least 8 characters.")
+            .Matches("[A-Z]").WithMessage("Password must contain at least one uppercase letter.")
+            .Matches("[0-9]").WithMessage("Password must contain at least one digit.");
+    }
+}


### PR DESCRIPTION
- RegisterUserCommand: record with Username and Password
- RegisterUserCommandValidator: rules for username (3-50 chars, alphanumeric+underscore) and password (8+ chars, uppercase, digit)
- RegisterUserHandler: checks for duplicate username, hashes password, assigns 'User' role, returns JWT token
- AuthController: POST /api/auth/register returns 201 with token
- ExceptionHandlingMiddleware: handle InvalidOperationException as 409 Conflict (used for duplicate username)